### PR TITLE
Add AWS Bedrock support as alternative to Anthropic API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.10"
 dependencies = [
   "fastapi>=0.110.0",
   "uvicorn[standard]>=0.23.0",
-  "anthropic>=0.34.0",
+  "anthropic[bedrock]>=0.40.0",
+  "boto3>=1.35.0",
   "httpx>=0.25.0",
   "pydantic>=2.0,<3",
   "pydantic-settings>=2.2.1",

--- a/src/base_agent/settings.py
+++ b/src/base_agent/settings.py
@@ -20,6 +20,13 @@ MOCK_EMPTY_MCP = os.getenv("MOCK_EMPTY_MCP", "false").lower() in {"1", "true", "
 THINKING_ENABLED = os.getenv("THINKING_ENABLED", "false").lower() in {"1", "true", "yes"}
 DEFAULT_THINKING_BUDGET_TOKENS = int(os.getenv("THINKING_BUDGET_TOKENS", "1024"))
 
+# AWS Bedrock configuration
+USE_BEDROCK = os.getenv("USE_BEDROCK", "false").lower() in {"1", "true", "yes"}
+AWS_PROFILE = os.getenv("AWS_PROFILE")
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+# Default Bedrock model (Claude Sonnet 4.5)
+DEFAULT_BEDROCK_MODEL = os.getenv("DEFAULT_BEDROCK_MODEL", "us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+
 
 def load_system_prompt() -> str:
     """Load the system prompt from the bundled prompts/system_prompt.txt file."""


### PR DESCRIPTION
## Summary
- Adds AWS Bedrock as an alternative LLM provider to Anthropic API
- When `USE_BEDROCK=true`, uses AWS credentials to connect to Bedrock instead of requiring `ANTHROPIC_API_KEY`
- Supports both AWS profile-based and explicit credential authentication

## Configuration
```bash
# Enable Bedrock
USE_BEDROCK=true
AWS_REGION=us-east-1

# Option 1: Use AWS profile
AWS_PROFILE=your-profile

# Option 2: Use explicit credentials
AWS_ACCESS_KEY_ID=...
AWS_SECRET_ACCESS_KEY=...
AWS_SESSION_TOKEN=...
```

## Test plan
- [x] Tested with AWS Bedrock credentials in docker-compose environment
- [x] Verified backwards compatibility with Anthropic API when USE_BEDROCK=false

🤖 Generated with [Claude Code](https://claude.com/claude-code)